### PR TITLE
add a skip

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -156,7 +156,7 @@ jobs:
   auto-version:
     name: Auto Version Bump
     runs-on: ubuntu-latest
-    needs: [lint-and-format, type-check, test, build, security-audit]
+    needs: [lint-and-format, type-check, test, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request includes a minor update to the CI/CD workflow configuration. The change removes the dependency on the `security-audit` job for the `auto-version` job.