### PR TITLE
bug fix

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -181,10 +181,14 @@ jobs:
       - name: Fix package
         run: npm pkg fix
 
-      - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: JS-DevTools/npm-publish@v3
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+
+      # - name: Publish to NPM
+      #   run: npm publish --access public
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-gpr:
     needs: [auto-version]


### PR DESCRIPTION
This pull request updates the CI/CD workflow in `.github/workflows/ci-cd.yaml` to replace manual NPM publishing steps with the `JS-DevTools/npm-publish` action for improved automation and maintainability.

Changes to CI/CD workflow:

* [`.github/workflows/ci-cd.yaml`](diffhunk://#diff-8ed13df95e3667964f78d1711225fae3857dfa8a46481166740dd4a28920331fL184-R191): Replaced the manual NPM publishing step (`npm publish --access public`) with the `JS-DevTools/npm-publish@v3` action, streamlining the process and leveraging a community-supported action.